### PR TITLE
fix: use PaypalListener to handle paypal result on Android

### DIFF
--- a/android/src/main/java/com/appchoose/braintree/Braintree.java
+++ b/android/src/main/java/com/appchoose/braintree/Braintree.java
@@ -38,6 +38,8 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
     private PayPalClient mPayPalClient;
     private PaypalListenerImpl mPaypalListener;
 
+    static int onHostPauseCounter = 0;
+
     private Callback successCallback;
     private Callback errorCallback;
 
@@ -62,6 +64,7 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
 
     @ReactMethod
     public void setup(final String url, final Callback successCallback, final Callback errorCallback) {
+        onHostPauseCounter = 0;
         String token = "";
         mCurrentActivity = (FragmentActivity) getCurrentActivity();
         try {
@@ -119,7 +122,7 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
     @Override
     public void onHostPause() {
         if (mPaypalListener != null) {
-            mPaypalListener.incrementOnHostPauseCounter();
+            onHostPauseCounter++;
         }
     }
 

--- a/android/src/main/java/com/appchoose/braintree/Braintree.java
+++ b/android/src/main/java/com/appchoose/braintree/Braintree.java
@@ -58,7 +58,6 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
         if (mCurrentActivity != null) {
             mCurrentActivity.setIntent(intent);
         }
-        // TODO: we should reinit paypalRequest ?? Not sure :/
     }
 
     @ReactMethod

--- a/android/src/main/java/com/appchoose/braintree/Braintree.java
+++ b/android/src/main/java/com/appchoose/braintree/Braintree.java
@@ -36,6 +36,7 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
     private FragmentActivity mCurrentActivity;
     private BraintreeClient mBraintreeClient;
     private PayPalClient mPayPalClient;
+    private PaypalListenerImpl mPaypalListener;
 
     private Callback successCallback;
     private Callback errorCallback;
@@ -81,6 +82,7 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
             errorCallback.invoke(e.getMessage());
         }
         mBraintreeClient = new BraintreeClient(mContext, token);
+        mPaypalListener = new PaypalListenerImpl(mContext);
         successCallback.invoke(token);
     }
 
@@ -89,9 +91,9 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
         mCurrentActivity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                PaypalListenerImpl paypalListener = new PaypalListenerImpl(mContext, shippingRequired);
+                mPaypalListener.setShippingRequired(shippingRequired);
                 mPayPalClient = new PayPalClient(mCurrentActivity, mBraintreeClient);
-                mPayPalClient.setListener(paypalListener);
+                mPayPalClient.setListener(mPaypalListener);
                 PayPalCheckoutRequest request = new PayPalCheckoutRequest(amount);
                 request.setCurrencyCode(currencyCode);
                 request.setIntent(PayPalPaymentIntent.AUTHORIZE);
@@ -117,7 +119,9 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
 
     @Override
     public void onHostPause() {
-        //NOTE: empty implementation
+        if (mPaypalListener != null) {
+            mPaypalListener.incrementOnHostPauseCounter();
+        }
     }
 
     @Override

--- a/android/src/main/java/com/appchoose/braintree/PaypalListenerImpl.java
+++ b/android/src/main/java/com/appchoose/braintree/PaypalListenerImpl.java
@@ -16,7 +16,6 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 public class PaypalListenerImpl implements PayPalListener {
     private final ReactApplicationContext context;
     private boolean shippingRequired;
-    private int onHostPauseCounter = 0;
 
     public PaypalListenerImpl(@NonNull ReactApplicationContext context) {
         this.context = context;
@@ -24,10 +23,6 @@ public class PaypalListenerImpl implements PayPalListener {
 
     public void setShippingRequired(boolean shippingRequired) {
         this.shippingRequired = shippingRequired;
-    }
-
-    public void incrementOnHostPauseCounter() {
-        onHostPauseCounter++;
     }
 
     private void sendEvent(String eventName,
@@ -76,11 +71,11 @@ public class PaypalListenerImpl implements PayPalListener {
             * If `onHostPauseCounter` is lower than 2, it means that user is still in the custom tabs
             * Otherwise there is a chance that the user opened the browser instead of custom tabs
             **/
-            if (((UserCanceledException) error).isExplicitCancelation() || onHostPauseCounter < 2) {
+            if (((UserCanceledException) error).isExplicitCancelation() || Braintree.onHostPauseCounter < 2) {
                 map.putString("error", "USER_CANCELLATION");
                 sendEvent("PaypalStatus", map);
             }
-        } else {
+        } else if (!error.getMessage().contains("The response contained inconsistent data.")) {
             map.putString("error", error.getMessage());
             sendEvent("PaypalStatus", map);
         }

--- a/android/src/main/java/com/appchoose/braintree/PaypalListenerImpl.java
+++ b/android/src/main/java/com/appchoose/braintree/PaypalListenerImpl.java
@@ -1,0 +1,71 @@
+package com.appchoose.braintree;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.braintreepayments.api.PayPalAccountNonce;
+import com.braintreepayments.api.PayPalListener;
+import com.braintreepayments.api.PostalAddress;
+import com.braintreepayments.api.UserCanceledException;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+
+public class PaypalListenerImpl implements PayPalListener {
+    private final ReactApplicationContext context;
+    private boolean shippingRequired;
+
+    public PaypalListenerImpl(@NonNull ReactApplicationContext context, @NonNull boolean shippingRequired) {
+        this.context = context;
+        this.shippingRequired = shippingRequired;
+    }
+
+    private void sendEvent(String eventName,
+        @Nullable WritableMap params) {
+        context
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+            .emit(eventName, params);
+    }
+
+    private WritableMap getPayPalAddressMap(PostalAddress address) {
+        WritableNativeMap map = new WritableNativeMap();
+        map.putString("streetAddress", address.getStreetAddress());
+        map.putString("recipientName", address.getRecipientName());
+        map.putString("postalCode", address.getPostalCode());
+        map.putString("countryCodeAlpha2", address.getCountryCodeAlpha2());
+        map.putString("extendedAddress", address.getExtendedAddress());
+        map.putString("region", address.getRegion());
+        map.putString("locality", address.getLocality());
+        return map;
+    }
+
+    @Override
+    public void onPayPalSuccess(@NonNull PayPalAccountNonce payPalAccountNonce) {
+        WritableNativeMap map = new WritableNativeMap();
+        map.putString("nonce", payPalAccountNonce.getString());
+        map.putString("email", payPalAccountNonce.getEmail());
+        map.putString("firstName", payPalAccountNonce.getFirstName());
+        map.putString("lastName", payPalAccountNonce.getLastName());
+        map.putString("phone", payPalAccountNonce.getPhone());
+        final PostalAddress shippingAddress = payPalAccountNonce.getShippingAddress();
+        if (shippingRequired && shippingAddress != null) {
+            map.putMap("shippingAddress", getPayPalAddressMap(shippingAddress));
+        }
+        sendEvent("PaypalStatus", map);
+    }
+
+    @Override
+    public void onPayPalFailure(@NonNull Exception error) {
+        WritableNativeMap map = new WritableNativeMap();
+        if (error instanceof UserCanceledException) {
+            map.putString("error", "USER_CANCELLATION");
+        } else {
+            map.putString("error", error.getMessage());
+        }
+        sendEvent("PaypalStatus", map);
+    }
+
+
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-braintree-custom-ui",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Cross platform Braintree module",
   "main": "index",
   "author": {


### PR DESCRIPTION
Pour tester, on peut utiliser la version : `1.2.0-unreleased`

Si la personne ouvre son navigateur et revient sur l'app sans laisser faire le deeplink cela sera considéré comme un cancel : https://github.com/braintree/braintree_android/issues/557